### PR TITLE
*: rename NewApiStorageLessResource to NewApiResourceWithStorage

### DIFF
--- a/cmd/apiregister-gen/generators/versioned_generator.go
+++ b/cmd/apiregister-gen/generators/versioned_generator.go
@@ -18,9 +18,9 @@ package generators
 
 import (
 	"io"
+	"text/template"
 
 	"k8s.io/gengo/generator"
-	"text/template"
 )
 
 type versionedGenerator struct {
@@ -77,7 +77,7 @@ var (
 			&{{ $api.Group }}.{{ $api.Kind }}StatusStrategy{builders.StatusStorageStrategySingleton},
 		),
 		{{ range $subresource := $api.Subresources -}}
-		builders.NewApiStoragelessResource(
+		builders.NewApiResourceWithStorage(
 			{{ $api.Group }}.Internal{{ $subresource.REST }},
 			func() runtime.Object { return &{{ $subresource.Request }}{} }, // Register versioned resource
 			&{{ $api.Group }}.{{ $subresource.REST }}{ {{$api.Group}}.New{{$api.Kind}}Registry({{$api.Group}}{{$api.Kind}}Storage) },

--- a/pkg/builders/api_versioned_resource_builder.go
+++ b/pkg/builders/api_versioned_resource_builder.go
@@ -35,7 +35,7 @@ import (
 // strategy - unversionedBuilder from calling NewUnversionedXXX()
 // new - function for creating new empty VERSIONED instances - e.g. func() runtime.Object { return &Deployment{} }
 // newList - function for creating an empty list of VERSIONED instances - e.g. func() runtime.Object { return &DeploymentList{} }
-// storeFunc - override storage defaults
+// storeBuilder - builder for creating the store
 func NewApiResource(
 	unversionedBuilder UnversionedResourceBuilder,
 	schemeFns SchemeFns,
@@ -51,13 +51,12 @@ func NewApiResource(
 	}
 }
 
-// NewApiStoragelessResource returns a new versionedResourceBuilder for registering endpoints for
-// subresources that are not persisted to storage.
+// NewApiResourceWithStorage returns a new versionedResourceBuilder for registering endpoints that
+// does not require standard storage (e.g. subresources reuses the storage for the parent resource).
 // strategy - unversionedBuilder from calling NewUnversionedXXX()
 // new - function for creating new empty VERSIONED instances - e.g. func() runtime.Object { return &Deployment{} }
-// newList - function for creating an empty list of VERSIONED instances - e.g. func() runtime.Object { return &DeploymentList{} }
-// restFunc - returns the REST implementation for this resource
-func NewApiStoragelessResource(
+// storage - storage for manipulating the resource
+func NewApiResourceWithStorage(
 	unversionedBuilder UnversionedResourceBuilder,
 	new func() runtime.Object,
 	storage rest.Storage) *versionedResourceBuilder {


### PR DESCRIPTION
NewApiStoragelessResource actually allows you to pass in a custom storage instead of using the standard impl.

It is better to name it correctly. Also we can use the same func for API Resource with custom REST storage when needed.

/cc @pwittrock 