### PR TITLE
Test support for controllers

### DIFF
--- a/cmd/apiregister-gen/generators/controller_generator.go
+++ b/cmd/apiregister-gen/generators/controller_generator.go
@@ -70,6 +70,9 @@ type {{.Target.Kind}}Controller struct {
 	controller *{{.Target.Kind}}ControllerImpl
 
 	Name string
+
+	BeforeReconcile func(key string)
+	AfterReconcile  func(key string, err error)
 }
 
 // NewController returns a new {{.Target.Kind}}Controller for responding to {{.Target.Kind}} events
@@ -81,7 +84,7 @@ func New{{.Target.Kind}}Controller(config *rest.Config, si *sharedinformers.Shar
 	uc.Init(config, si, q)
 
 	queue := &controller.QueueWorker{q, 10, "{{.Target.Kind}}", nil}
-	c := &{{.Target.Kind}}Controller{queue, uc, "{{.Target.Kind}}"}
+	c := &{{.Target.Kind}}Controller{queue, uc, "{{.Target.Kind}}", nil, nil}
 	queue.Reconcile = c.reconcile
 	return c
 }
@@ -90,23 +93,38 @@ func (c *{{.Target.Kind}}Controller) GetName() string {
 	return c.Name
 }
 
-func (c *{{.Target.Kind}}Controller) reconcile(key string) error {
-	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+func (c *{{.Target.Kind}}Controller) reconcile(key string) (err error) {
+	var namespace, name string
+
+	if c.BeforeReconcile != nil {
+		c.BeforeReconcile(key)
+	}
+	if c.AfterReconcile != nil {
+		// Wrap in a function so err is evaluated after it is set
+		defer func() { c.AfterReconcile(key, err) }()
+	}
+
+	namespace, name, err = cache.SplitMetaNamespaceKey(key)
 	if err != nil {
-		return err
+		return
 	}
 
 	u, err := c.controller.Get(namespace, name)
 	if errors.IsNotFound(err) {
 		glog.Infof("Not doing work for {{.Target.Kind}} %v because it has been deleted", key)
-		return nil
+		// Set error so it is picked up by AfterReconcile and the return function
+		err = nil
+		return
 	}
 	if err != nil {
 		glog.Errorf("Unable to retrieve {{.Target.Kind}} %v from store: %v", key, err)
-		return err
+		return
 	}
 
-	return c.controller.Reconcile(u)
+	// Set error so it is picked up by AfterReconcile and the return function
+	err = c.controller.Reconcile(u)
+
+	return
 }
 
 func (c *{{.Target.Kind}}Controller) Run(stopCh <-chan struct{}) {

--- a/cmd/apiregister-gen/generators/controller_generator.go
+++ b/cmd/apiregister-gen/generators/controller_generator.go
@@ -238,25 +238,18 @@ type SharedInformers struct {
 }
 
 // newSharedInformers returns a set of started informers
-func NewSharedInformers(config *rest.Config, stop <-chan struct{}) *SharedInformers {
+func NewSharedInformers(config *rest.Config, shutdown <-chan struct{}) *SharedInformers {
 	cs := clientset.NewForConfigOrDie(config)
 	si := &SharedInformers{externalversions.NewSharedInformerFactory(cs, 10*time.Minute)}
-	si.startInformers(stop)
+	si.startInformers(shutdown)
 	return si
 }
 
 // startInformers starts all of the informers
-func (si *SharedInformers) startInformers(stop <-chan struct{}) {
-	shutdown := make(chan struct{})
+func (si *SharedInformers) startInformers(shutdown <-chan struct{}) {
 	{{ range $c := . -}}
 	go si.Factory.{{title $c.Target.Group}}().{{title $c.Target.Version}}().{{title $c.Resource}}().Informer().Run(shutdown)
 	{{ end -}}
-	go func() {
-		m := <-stop
-		{{ range $c := . -}}
-		shutdown <- m
-		{{ end -}}
-	}()
 }
 
 `

--- a/cmd/apiserver-boot/boot/init.go
+++ b/cmd/apiserver-boot/boot/init.go
@@ -89,6 +89,9 @@ func main() {
 
 	controllers, _ := controller.GetAllControllers(config)
 	controllerlib.StartControllerManager(controllers...)
+
+	// Blockforever
+	select {}
 }
 `
 

--- a/cmd/apiserver-boot/boot/run.go
+++ b/cmd/apiserver-boot/boot/run.go
@@ -73,6 +73,7 @@ func RunRun(cmd *cobra.Command, args []string) {
 	// Start controller manager
 	go RunControllerManager()
 
+	fmt.Printf("to test the server run `kubectl --kubeconfig %s version`\n", config)
 	for {
 		time.Sleep(time.Minute)
 	}
@@ -112,8 +113,6 @@ func RunApiserver() *exec.Cmd {
 		apiserverCmd.Stderr = os.Stderr
 		apiserverCmd.Stdout = os.Stdout
 	}
-
-	fmt.Printf("to test the server run `kubectl --kubeconfig %s version`\n", config)
 
 	err := apiserverCmd.Run()
 	if err != nil {

--- a/cmd/apiserver-boot/boot/run.go
+++ b/cmd/apiserver-boot/boot/run.go
@@ -41,12 +41,14 @@ var printcontrollermanager bool
 var printetcd bool
 
 func AddRunCmd(cmd *cobra.Command) {
-	runCmd.Flags().StringVar(&server, "server", "", "path to apiserver binary to run")
+	runCmd.Flags().StringVar(&server, "apiserver", "", "path to apiserver binary to run")
 	runCmd.Flags().StringVar(&controllermanager, "controller-manager", "", "path to controller-manager binary to run")
 	runCmd.Flags().StringVar(&etcd, "etcd", "", "if non-empty, use this etcd instead of starting a new one")
+
 	runCmd.Flags().StringVar(&config, "config", "kubeconfig", "path to the kubeconfig to write for using kubectl")
-	runCmd.Flags().BoolVar(&printapiserver, "printapiserver", true, "if true, pipe the apiserver stdout and stderr")
-	runCmd.Flags().BoolVar(&printcontrollermanager, "printcontrollermanager", true, "if true, pipe the controller-manager stdout and stderr")
+
+	runCmd.Flags().BoolVar(&printapiserver, "print-apiserver", true, "if true, pipe the apiserver stdout and stderr")
+	runCmd.Flags().BoolVar(&printcontrollermanager, "print-controller-manager", true, "if true, pipe the controller-manager stdout and stderr")
 	runCmd.Flags().BoolVar(&printetcd, "printetcd", false, "if true, pipe the etcd stdout and stderr")
 	cmd.AddCommand(runCmd)
 }

--- a/example/Makefile
+++ b/example/Makefile
@@ -17,6 +17,7 @@ all: test
 test: build
 	go test github.com/kubernetes-incubator/apiserver-builder/example/pkg/apis/miskatonic/v1beta1
 	go test github.com/kubernetes-incubator/apiserver-builder/example/pkg/apis/innsmouth/v1
+	go test github.com/kubernetes-incubator/apiserver-builder/example/pkg/controller/university
 	bash -c "find pkg/apis/ -name apiserver.local.config | xargs rm -rf"
 
 build: generate

--- a/example/cmd/controller-manager/main.go
+++ b/example/cmd/controller-manager/main.go
@@ -35,4 +35,7 @@ func main() {
 
 	controllers, _ := examplecontroller.GetAllControllers(config)
 	controller.StartControllerManager(controllers...)
+
+	// Blockforever
+	select {}
 }

--- a/example/pkg/controller/university/university_controller_test.go
+++ b/example/pkg/controller/university/university_controller_test.go
@@ -27,13 +27,13 @@ func TestReconcileUniversity(t *testing.T) {
 	afterChan := make(chan struct{})
 	expectedKey := "test-controller-universities/miskatonic-university"
 	controller.BeforeReconcile = func(key string) {
-		close(beforeChan)
+		defer close(beforeChan)
 		if key != expectedKey {
 			t.Fatalf("Expected reconcile before university %s got %s", expectedKey, key)
 		}
 	}
 	controller.AfterReconcile = func(key string, err error) {
-		close(afterChan)
+		defer close(afterChan)
 		if key != expectedKey {
 			t.Fatalf("Expected reconcile after university %s got %s", expectedKey, key)
 		}

--- a/example/pkg/controller/university/university_controller_test.go
+++ b/example/pkg/controller/university/university_controller_test.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package university_test
+
+import (
+	v1beta1miskatonic "github.com/kubernetes-incubator/apiserver-builder/example/pkg/apis/miskatonic/v1beta1"
+	"testing"
+	"time"
+)
+
+func TestReconcileUniversity(t *testing.T) {
+	beforeChan := make(chan struct{})
+	afterChan := make(chan struct{})
+	expectedKey := "test-controller-universities/miskatonic-university"
+	controller.BeforeReconcile = func(key string) {
+		close(beforeChan)
+		if key != expectedKey {
+			t.Fatalf("Expected reconcile before university %s got %s", expectedKey, key)
+		}
+	}
+	controller.AfterReconcile = func(key string, err error) {
+		close(afterChan)
+		if key != expectedKey {
+			t.Fatalf("Expected reconcile after university %s got %s", expectedKey, key)
+		}
+		if err != nil {
+			t.Fatalf("Expected no error on reconcile university %s", key)
+		}
+	}
+
+	client := cs.MiskatonicV1beta1Client
+	intf := client.Universities("test-controller-universities")
+
+	univ := &v1beta1miskatonic.University{}
+	univ.Name = "miskatonic-university"
+	univ.Spec.FacultySize = 7
+
+	// Make sure we can create the resource
+	if _, err := intf.Create(univ); err != nil {
+		t.Fatalf("Failed to create %T %v", univ, err)
+	}
+
+	select {
+	case <-beforeChan:
+	case <-time.After(time.Second * 2):
+		t.Fatalf("Create University event never reconciled")
+	}
+
+	select {
+	case <-afterChan:
+	case <-time.After(time.Second * 2):
+		t.Fatalf("Create University event never finished")
+	}
+}

--- a/example/pkg/controller/university/util_test.go
+++ b/example/pkg/controller/university/util_test.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package university_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/kubernetes-incubator/apiserver-builder/example/pkg/apis"
+	"github.com/kubernetes-incubator/apiserver-builder/example/pkg/client/clientset_generated/clientset"
+	"github.com/kubernetes-incubator/apiserver-builder/example/pkg/controller/sharedinformers"
+	"github.com/kubernetes-incubator/apiserver-builder/example/pkg/controller/university"
+	"github.com/kubernetes-incubator/apiserver-builder/example/pkg/openapi"
+	"github.com/kubernetes-incubator/apiserver-builder/pkg/test"
+	"k8s.io/client-go/rest"
+)
+
+var testenv *test.TestEnvironment
+var config *rest.Config
+var cs *clientset.Clientset
+var controller *university.UniversityController
+var si *sharedinformers.SharedInformers
+
+// Do Test Suite setup / teardown
+func TestMain(m *testing.M) {
+	testenv = test.NewTestEnvironment()
+	config = testenv.Start(apis.GetAllApiBuilders(), openapi.GetOpenAPIDefinitions)
+	cs = clientset.NewForConfigOrDie(config)
+
+	shutdown := make(chan struct{})
+	si = sharedinformers.NewSharedInformers(config, shutdown)
+	controller = university.NewUniversityController(config, si)
+	controller.Run(shutdown)
+
+	retCode := m.Run()
+	close(shutdown)
+	os.Exit(retCode)
+}


### PR DESCRIPTION
- Support before/after hooks on reconcile methods
- Add integration testing for example controller
- Generating meaningful tests for types when creating them from apiserver-boot