### PR TITLE
Remove k8s.io/kubernetes dep and switch to ginkgo tests

### DIFF
--- a/cmd/apiserver-boot/boot/create_resource.go
+++ b/cmd/apiserver-boot/boot/create_resource.go
@@ -102,6 +102,11 @@ func createResource(boilerplate string) {
 		found = true
 	}
 
+	// write the suite if it is missing
+	typesFileName = fmt.Sprintf("%s_suite_test.go", strings.ToLower(versionName))
+	path = filepath.Join(dir, "pkg", "apis", groupName, versionName, typesFileName)
+	writeIfNotFound(path, "version-suite-test-template", resourceSuiteTestTemplate, a)
+
 	typesFileName = fmt.Sprintf("%s_types_test.go", strings.ToLower(kindName))
 	path = filepath.Join(dir, "pkg", "apis", groupName, versionName, typesFileName)
 	created = writeIfNotFound(path, "resource-test-template", resourceTestTemplate, a)
@@ -118,6 +123,9 @@ func createResource(boilerplate string) {
 			"Controller for %s/%s/%s already exists.\n", groupName, versionName, kindName)
 		found = true
 	}
+
+	path = filepath.Join(dir, "pkg", "controller", strings.ToLower(kindName), fmt.Sprintf("%s_suite_test.go", strings.ToLower(kindName)))
+	writeIfNotFound(path, "resource-controller-suite-test-template", controllerSuiteTestTemplate, a)
 
 	path = filepath.Join(dir, "pkg", "controller", strings.ToLower(kindName), "controller_test.go")
 	created = writeIfNotFound(path, "controller-test-template", controllerTestTemplate, a)
@@ -184,75 +192,108 @@ func ({{.Kind}}SchemeFns) DefaultingFunction(o interface{}) {
 
 `
 
+var resourceSuiteTestTemplate = `
+{{.BoilerPlate}}
+
+package {{.Version}}_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/kubernetes-incubator/apiserver-builder/pkg/test"
+	"k8s.io/client-go/rest"
+
+	"{{ .Repo }}/pkg/apis"
+	"{{ .Repo }}/pkg/client/clientset_generated/clientset"
+	"{{ .Repo }}/pkg/openapi"
+)
+
+var testenv *test.TestEnvironment
+var config *rest.Config
+var cs *clientset.Clientset
+
+func Test{{title .Version}}(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecsWithDefaultAndCustomReporters(t, "v1 Suite", []Reporter{test.NewlineReporter{}})
+}
+
+var _ = BeforeSuite(func() {
+	testenv = test.NewTestEnvironment()
+	config = testenv.Start(apis.GetAllApiBuilders(), openapi.GetOpenAPIDefinitions)
+	cs = clientset.NewForConfigOrDie(config)
+})
+
+var _ = AfterSuite(func() {
+	testenv.Stop()
+})
+`
+
 var resourceTestTemplate = `
 {{.BoilerPlate}}
 
 package {{.Version}}_test
 
 import (
-	"os"
-	"testing"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 
-	"github.com/kubernetes-incubator/apiserver-builder/pkg/test"
-	"k8s.io/client-go/rest"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"{{.Repo}}/pkg/apis"
-	"{{.Repo}}/pkg/client/clientset_generated/clientset"
-	"{{.Repo}}/pkg/openapi"
-	{{ .Group }}{{ .Version }} "{{ .Repo }}/pkg/apis/{{ .Group }}/{{ .Version }}"
+	. "{{.Repo}}/pkg/apis/{{.Group}}/{{.Version}}"
+	. "{{.Repo}}/pkg/client/clientset_generated/clientset/typed/{{.Group}}/{{.Version}}"
 )
 
-var testenv *test.TestEnvironment
-var config *rest.Config
-var client *clientset.Clientset
+var _ = Describe("{{.Kind}}", func() {
+	var instance {{ .Kind}}
+	var expected {{ .Kind}}
+	var client {{ .Kind}}Interface
 
-// Do Test Suite setup / teardown
-func TestMain(m *testing.M) {
-	testenv = test.NewTestEnvironment()
-	config = testenv.Start(apis.GetAllApiBuilders(), openapi.GetOpenAPIDefinitions)
-	client = clientset.NewForConfigOrDie(config)
-	retCode := m.Run()
-	testenv.Stop()
-	os.Exit(retCode)
-}
+	BeforeEach(func() {
+		instance = {{ .Kind}}{}
+		instance.Name = "instance-1"
 
-func TestCreateDelete{{.Kind}}(t *testing.T) {
-	intf := client.{{ title .Group }}{{ title .Version }}Client.{{ .PluralizedKind }}("test-create-delete-{{ lower .Kind }}")
+		expected = instance
+	})
 
-	instance := &{{ .Group }}{{ .Version }}.{{ .Kind }}{}
-	instance.Name = "{{ lower .Kind }}-1"
+	AfterEach(func() {
+		client.Delete(instance.Name, &metav1.DeleteOptions{})
+	})
 
-	// Make sure we can create the resource
-	if _, err := intf.Create(instance); err != nil {
-		t.Fatalf("Failed to create %T %v", instance, err)
-	}
+	Describe("when sending a storage request", func() {
+		Context("for a valid config", func() {
+			It("should provide CRUD access to the object", func() {
+				client = cs.{{ title .Group}}{{title .Version}}Client.{{title .Resource}}("{{lower .Kind}}-test-valid")
 
-	// Make sure we can list the resource
-	result, err := intf.List(metav1.ListOptions{})
-	if err != nil {
-		t.Fatalf("Failed to list %T %v", instance, err)
-	}
-	if len(result.Items) != 1 {
-		t.Fatalf("Expected to find 1 {{.Kind}}, found %d", len(result.Items))
-	}
-	actual := result.Items[0]
-	if actual.Name != instance.Name {
-		t.Fatalf("Expected to find {{.Kind}} named %s, found %s", instance.Name, actual.Name)
-	}
+				By("returning success from the create request")
+				actual, err := client.Create(&instance)
+				Expect(err).ShouldNot(HaveOccurred())
 
-	// Make sure we can delete the resource
-	if err = intf.Delete(instance.Name, &metav1.DeleteOptions{}); err != nil {
-		t.Fatalf("Failed to delete %T %v", instance, err)
-	}
-	result, err = intf.List(metav1.ListOptions{})
-	if err != nil {
-		t.Fatalf("Failed to list %T %v", instance, err)
-	}
-	if len(result.Items) > 0 {
-		t.Fatalf("Expected to find 0 {{ .Kind }}, found %d", len(result.Items))
-	}
-}
+				By("defaulting the expected fields")
+				Expect(actual.Spec).To(Equal(expected.Spec))
+
+				By("returning the item for list requests")
+				result, err := client.List(metav1.ListOptions{})
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(result.Items).To(HaveLen(1))
+				Expect(result.Items[0].Spec).To(Equal(expected.Spec))
+
+				By("returning the item for get requests")
+				actual, err = client.Get(instance.Name, metav1.GetOptions{})
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(actual.Spec).To(Equal(expected.Spec))
+
+				By("deleting the item for delete requests")
+				err = client.Delete(instance.Name, &metav1.DeleteOptions{})
+				Expect(err).ShouldNot(HaveOccurred())
+				result, err = client.List(metav1.ListOptions{})
+				Expect(err).ShouldNot(HaveOccurred())
+				Expect(result.Items).To(HaveLen(0))
+			})
+		})
+	})
+})
 `
 
 var resourceControllerTemplate = `
@@ -313,93 +354,129 @@ func (c *{{.Kind}}ControllerImpl) Get(namespace, name string) (*{{.Version}}.{{.
 }
 `
 
+var controllerSuiteTestTemplate = `
+{{.BoilerPlate}}
+
+package {{lower .Kind}}_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/client-go/rest"
+	"github.com/kubernetes-incubator/apiserver-builder/pkg/test"
+
+	"{{ .Repo }}/pkg/apis"
+	"{{ .Repo }}/pkg/client/clientset_generated/clientset"
+	"{{ .Repo }}/pkg/openapi"
+	"{{ .Repo }}/pkg/controller/sharedinformers"
+	"{{ .Repo }}/pkg/controller/{{lower .Kind}}"
+)
+
+var testenv *test.TestEnvironment
+var config *rest.Config
+var cs *clientset.Clientset
+var shutdown chan struct{}
+var controller *{{ lower .Kind }}.{{ .Kind }}Controller
+var si *sharedinformers.SharedInformers
+
+func Test{{.Kind}}(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecsWithDefaultAndCustomReporters(t, "{{ .Kind }} Suite", []Reporter{test.NewlineReporter{}})
+}
+
+var _ = BeforeSuite(func() {
+	testenv = test.NewTestEnvironment()
+	config = testenv.Start(apis.GetAllApiBuilders(), openapi.GetOpenAPIDefinitions)
+	cs = clientset.NewForConfigOrDie(config)
+
+	shutdown = make(chan struct{})
+	si = sharedinformers.NewSharedInformers(config, shutdown)
+	controller = {{ lower .Kind }}.New{{ .Kind}}Controller(config, si)
+	controller.Run(shutdown)
+})
+
+var _ = AfterSuite(func() {
+	close(shutdown)
+	testenv.Stop()
+})
+`
+
 var controllerTestTemplate = `
 {{.BoilerPlate}}
 
 package {{ lower .Kind }}_test
 
 import (
-	"os"
-	"testing"
 	"time"
 
-	"github.com/kubernetes-incubator/apiserver-builder/pkg/test"
-	"k8s.io/client-go/rest"
+	. "{{ .Repo }}/pkg/apis/{{ .Group }}/{{ .Version }}"
+	. "{{ .Repo }}/pkg/client/clientset_generated/clientset/typed/{{ .Group }}/{{ .Version }}"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
 
-	"{{ .Repo }}/pkg/apis"
-	{{ .Group }}{{ .Version }} "{{ .Repo }}/pkg/apis/{{ .Group }}/{{ .Version}}"
-	"{{ .Repo }}/pkg/client/clientset_generated/clientset"
-	"{{ .Repo }}/pkg/controller/sharedinformers"
-	"{{ .Repo }}/pkg/controller/{{ lower .Kind }}"
-	"{{ .Repo }}/pkg/openapi"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var testenv *test.TestEnvironment
-var config *rest.Config
-var client *clientset.Clientset
-var controller *{{lower .Kind }}.{{ .Kind }}Controller
-var si *sharedinformers.SharedInformers
+var _ = Describe("{{ .Kind }} controller", func() {
+	var instance {{ .Kind }}
+	var expectedKey string
+	var client {{ .Kind }}Interface
+	var before chan struct{}
+	var after chan struct{}
 
-// Do Test Suite setup / teardown
-func TestMain(m *testing.M) {
-	testenv = test.NewTestEnvironment()
-	config = testenv.Start(apis.GetAllApiBuilders(), openapi.GetOpenAPIDefinitions)
-	client = clientset.NewForConfigOrDie(config)
+	BeforeEach(func() {
+		instance = {{ .Kind }}{}
+		instance.Name = "instance-1"
+		expectedKey = "{{lower .Kind }}-controller-test-handler/instance-1"
+	})
 
-	shutdown := make(chan struct{})
-	si = sharedinformers.NewSharedInformers(config, shutdown)
-	controller = {{ lower .Kind }}.New{{ .Kind }}Controller(config, si)
-	controller.Run(shutdown)
+	AfterEach(func() {
+		client.Delete(instance.Name, &metav1.DeleteOptions{})
+	})
 
-	retCode := m.Run()
-	close(shutdown)
-	os.Exit(retCode)
-}
+	Describe("when creating a new object", func() {
+		It("invoke the reconcile method", func() {
+			client = cs.{{title .Group}}{{title .Version}}Client.{{ title .Resource }}("{{lower .Kind }}-controller-test-handler")
+			before = make(chan struct{})
+			after = make(chan struct{})
 
+			actualKey := ""
+			var actualErr error = nil
 
-func TestReconcile{{ .Kind }}(t *testing.T) {
-	beforeChan := make(chan struct{})
-	afterChan := make(chan struct{})
+			// Setup test callbacks to be called when the message is reconciled
+			controller.BeforeReconcile = func(key string) {
+				defer close(before)
+				actualKey = key
+			}
+			controller.AfterReconcile = func(key string, err error) {
+				defer close(after)
+				actualKey = key
+				actualErr = err
+			}
 
-	ns := "test-controller-{{ lower .Kind }}"
-	name := "{{ lower .Kind }}-1"
-	expectedKey := ns + "/" + name
-	controller.BeforeReconcile = func(key string) {
-		defer close(beforeChan)
-		if key != expectedKey {
-			t.Fatalf("Expected reconcile before %s got %s", expectedKey, key)
-		}
-	}
-	controller.AfterReconcile = func(key string, err error) {
-		defer close(afterChan)
-		if key != expectedKey {
-			t.Fatalf("Expected reconcile after %s got %s", expectedKey, key)
-		}
-		if err != nil {
-			t.Fatalf("Expected no error on reconcile university %s", key)
-		}
-	}
+			// Create an instance
+			_, err := client.Create(&instance)
+			Expect(err).ShouldNot(HaveOccurred())
 
-	intf := client.{{ title .Group }}{{ title .Version }}Client.{{ .PluralizedKind }}(ns)
+			// Verify reconcile function is called against the correct key
+			select {
+			case <-before:
+				Expect(actualKey).To(Equal(expectedKey))
+				Expect(actualErr).ShouldNot(HaveOccurred())
+			case <-time.After(time.Second * 2):
+				Fail("reconcile never called")
+			}
 
-	instance := &{{ .Group }}{{ .Version }}.{{ .Kind }}{}
-	instance.Name = name
-
-	// Make sure we can create the resource
-	if _, err := intf.Create(instance); err != nil {
-		t.Fatalf("Failed to create %T %v", instance, err)
-	}
-
-	select {
-	case <-beforeChan:
-	case <-time.After(time.Second * 2):
-		t.Fatalf("Create {{ .Kind }} event never reconciled")
-	}
-
-	select {
-	case <-afterChan:
-	case <-time.After(time.Second * 2):
-		t.Fatalf("Create {{ .Kind }} event never finished")
-	}
-}
+			select {
+			case <-after:
+				Expect(actualKey).To(Equal(expectedKey))
+				Expect(actualErr).ShouldNot(HaveOccurred())
+			case <-time.After(time.Second * 2):
+				Fail("reconcile never finished")
+			}
+		})
+	})
+})
 `

--- a/cmd/apiserver-boot/boot/glide.go
+++ b/cmd/apiserver-boot/boot/glide.go
@@ -114,6 +114,10 @@ type glideTemplateArguments struct {
 var glideTemplate = `
 package: {{.Repo}}
 import:
+- package: k8s.io/apimachinery
+- package: k8s.io/apiserver
+- package: k8s.io/client-go
+# Freeze the following deps because they don't all provide backwards compatibility
 - package: github.com/go-openapi/analysis
   version: b44dc874b601d9e4e2f6e19140e794ba24bead3b
 - package: github.com/go-openapi/jsonpointer
@@ -134,13 +138,6 @@ import:
   version: 7b1b6e8dc027253d45fc029bc269d1c019f83a34
 - package: github.com/spf13/pflag
   version: d90f37a48761fe767528f31db1955e4f795d652f
-- package: k8s.io/apimachinery
-- package: k8s.io/apiserver
-- package: k8s.io/client-go
-- package: k8s.io/gengo
-- package: k8s.io/kubernetes
-  subpackages:
-  - pkg/api
 ignore:
 - {{.Repo}}
 `

--- a/cmd/apiserver-boot/boot/init.go
+++ b/cmd/apiserver-boot/boot/init.go
@@ -119,7 +119,6 @@ package main
 import (
 	// Make sure glide gets these dependencies
 	_ "k8s.io/apimachinery/pkg/apis/meta/v1"
-	_ "k8s.io/kubernetes/pkg/api"
 	_ "github.com/go-openapi/loads"
 
 	"github.com/kubernetes-incubator/apiserver-builder/pkg/cmd/server"


### PR DESCRIPTION
- Remove unnecessary k8s.io/kubernetes dependency from glide
- Switch apiserver-boot create-resource to generate tests using ginkgo