### PR TITLE
cmd: simplify fatal error printing

### DIFF
--- a/cmd/apiregister-gen/generators/parser.go
+++ b/cmd/apiregister-gen/generators/parser.go
@@ -17,8 +17,7 @@ limitations under the License.
 package generators
 
 import (
-	"fmt"
-	"os"
+	"log"
 	"path/filepath"
 	"strings"
 
@@ -331,9 +330,8 @@ func (b *APIsBuilder) GetSubresources(c *APIResource) map[string]*APISubresource
 			sr.Request, sr.ImportPackage = b.GetNameAndImport(tags)
 		}
 		if v, found := r[sr.Path]; found {
-			fmt.Fprintf(os.Stderr, "Multiple subresources registered for path %s: %v %v",
+			log.Fatalf("Multiple subresources registered for path %s: %v %v",
 				sr.Path, v, subresource)
-			os.Exit(-1)
 		}
 		r[sr.Path] = sr
 	}
@@ -370,10 +368,9 @@ func ParseResourceTag(tag string) ResourceTags {
 	for _, elem := range strings.Split(tag, ",") {
 		kv := strings.Split(elem, "=")
 		if len(kv) != 2 {
-			fmt.Fprintf(os.Stderr, "// +resource: tags must be key value pairs.  Expected "+
+			log.Fatalf("// +resource: tags must be key value pairs.  Expected "+
 				"keys [path=<subresourcepath>] "+
 				"Got string: [%s]", tag)
-			os.Exit(-1)
 		}
 		value := kv[1]
 		switch kv[0] {
@@ -398,10 +395,9 @@ func ParseControllerTag(tag string) ControllerTags {
 	for _, elem := range strings.Split(tag, ",") {
 		kv := strings.Split(elem, "=")
 		if len(kv) != 2 {
-			fmt.Fprintf(os.Stderr, "// +controller: tags must be key value pairs.  Expected "+
+			log.Fatalf("// +controller: tags must be key value pairs.  Expected "+
 				"keys [group=<group>,version=<version>,kind=<kind>,resource=<resource>] "+
 				"Got string: [%s]", tag)
-			os.Exit(-1)
 		}
 		value := kv[1]
 		switch kv[0] {
@@ -432,10 +428,9 @@ func ParseSubresourceTag(c *APIResource, tag string) SubresourceTags {
 	for _, elem := range strings.Split(tag, ",") {
 		kv := strings.Split(elem, "=")
 		if len(kv) != 2 {
-			fmt.Fprintf(os.Stderr, "// +subresource: tags must be key value pairs.  Expected "+
+			log.Fatalf("// +subresource: tags must be key value pairs.  Expected "+
 				"keys [request=<requestType>,rest=<restImplType>,path=<subresourcepath>] "+
 				"Got string: [%s]", tag)
-			os.Exit(-1)
 		}
 		value := kv[1]
 		switch kv[0] {

--- a/cmd/apiserver-boot/boot/build.go
+++ b/cmd/apiserver-boot/boot/build.go
@@ -18,11 +18,13 @@ package boot
 
 import (
 	"fmt"
-	"github.com/spf13/cobra"
+	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/spf13/cobra"
 )
 
 var createBuildCmd = &cobra.Command{
@@ -44,8 +46,7 @@ func RunBuild(cmd *cobra.Command, args []string) {
 	c.Stdout = os.Stdout
 	err := c.Run()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		os.Exit(-1)
+		log.Fatal(err)
 	}
 
 	path = filepath.Join("cmd", "controller", "main.go")
@@ -55,7 +56,6 @@ func RunBuild(cmd *cobra.Command, args []string) {
 	c.Stdout = os.Stdout
 	err = c.Run()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		os.Exit(-1)
+		log.Fatal(err)
 	}
 }

--- a/cmd/apiserver-boot/boot/create_resource.go
+++ b/cmd/apiserver-boot/boot/create_resource.go
@@ -18,6 +18,7 @@ package boot
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -45,20 +46,16 @@ func AddCreateResource(cmd *cobra.Command) {
 
 func RunCreateResource(cmd *cobra.Command, args []string) {
 	if len(domain) == 0 {
-		fmt.Fprintf(os.Stderr, "apiserver-boot create-resource requires the --domain flag\n")
-		os.Exit(-1)
+		log.Fatal("apiserver-boot create-resource requires the --domain flag")
 	}
 	if len(groupName) == 0 {
-		fmt.Fprintf(os.Stderr, "apiserver-boot create-resource requires the --group flag\n")
-		os.Exit(-1)
+		log.Fatal("apiserver-boot create-resource requires the --group flag")
 	}
 	if len(versionName) == 0 {
-		fmt.Fprintf(os.Stderr, "apiserver-boot create-resource requires the --version flag\n")
-		os.Exit(-1)
+		log.Fatal("apiserver-boot create-resource requires the --version flag")
 	}
 	if len(kindName) == 0 {
-		fmt.Fprintf(os.Stderr, "apiserver-boot create-resource requires the --kind flag\n")
-		os.Exit(-1)
+		log.Fatal("apiserver-boot create-resource requires the --kind flag")
 	}
 	if len(resourceName) == 0 {
 		resourceName = inflect.NewDefaultRuleset().Pluralize(strings.ToLower(kindName))
@@ -77,8 +74,7 @@ func RunCreateResource(cmd *cobra.Command, args []string) {
 func createResource(boilerplate string) {
 	dir, err := os.Getwd()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
-		os.Exit(-1)
+		log.Fatal(err)
 	}
 	typesFileName := fmt.Sprintf("%s_types.go", strings.ToLower(kindName))
 	path := filepath.Join(dir, "pkg", "apis", groupName, versionName, typesFileName)
@@ -97,8 +93,8 @@ func createResource(boilerplate string) {
 
 	created := writeIfNotFound(path, "resource-template", resourceTemplate, a)
 	if !created {
-		fmt.Fprintf(os.Stderr,
-			"API group version kind %s/%s/%s already exists.\n", groupName, versionName, kindName)
+		log.Printf("API group version kind %s/%s/%s already exists.",
+			groupName, versionName, kindName)
 		found = true
 	}
 
@@ -111,16 +107,16 @@ func createResource(boilerplate string) {
 	path = filepath.Join(dir, "pkg", "apis", groupName, versionName, typesFileName)
 	created = writeIfNotFound(path, "resource-test-template", resourceTestTemplate, a)
 	if !created {
-		fmt.Fprintf(os.Stderr,
-			"API group version kind %s/%s/%s test already exists.\n", groupName, versionName, kindName)
+		log.Printf("API group version kind %s/%s/%s test already exists.",
+			groupName, versionName, kindName)
 		found = true
 	}
 
 	path = filepath.Join(dir, "pkg", "controller", strings.ToLower(kindName), "controller.go")
 	created = writeIfNotFound(path, "resource-controller-template", resourceControllerTemplate, a)
 	if !created {
-		fmt.Fprintf(os.Stderr,
-			"Controller for %s/%s/%s already exists.\n", groupName, versionName, kindName)
+		log.Printf("Controller for %s/%s/%s already exists.",
+			groupName, versionName, kindName)
 		found = true
 	}
 
@@ -130,8 +126,8 @@ func createResource(boilerplate string) {
 	path = filepath.Join(dir, "pkg", "controller", strings.ToLower(kindName), "controller_test.go")
 	created = writeIfNotFound(path, "controller-test-template", controllerTestTemplate, a)
 	if !created {
-		fmt.Fprintf(os.Stderr,
-			"Controller test for %s/%s/%s already exists.\n", groupName, versionName, kindName)
+		log.Printf("Controller test for %s/%s/%s already exists.",
+			groupName, versionName, kindName)
 		found = true
 	}
 

--- a/cmd/apiserver-boot/boot/create_resource_group.go
+++ b/cmd/apiserver-boot/boot/create_resource_group.go
@@ -17,7 +17,7 @@ limitations under the License.
 package boot
 
 import (
-	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 
@@ -40,12 +40,10 @@ func AddCreateGroup(cmd *cobra.Command) {
 
 func RunCreateGroup(cmd *cobra.Command, args []string) {
 	if len(domain) == 0 {
-		fmt.Fprintf(os.Stderr, "apiserver-boot create-group requires the --domain flag\n")
-		os.Exit(-1)
+		log.Fatalf("apiserver-boot create-group requires the --domain flag")
 	}
 	if len(groupName) == 0 {
-		fmt.Fprintf(os.Stderr, "apiserver-boot create-group requires the --groupName flag\n")
-		os.Exit(-1)
+		log.Fatalf("apiserver-boot create-group requires the --groupName flag")
 	}
 	cr := getCopyright()
 	createGroup(cr)
@@ -54,8 +52,7 @@ func RunCreateGroup(cmd *cobra.Command, args []string) {
 func createGroup(boilerplate string) {
 	dir, err := os.Getwd()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
-		os.Exit(-1)
+		log.Fatal(err)
 	}
 	path := filepath.Join(dir, "pkg", "apis", groupName, "doc.go")
 	created := writeIfNotFound(path, "group-template", groupTemplate, groupTemplateArgs{
@@ -64,8 +61,7 @@ func createGroup(boilerplate string) {
 		groupName,
 	})
 	if !created && !ignoreExists {
-		fmt.Fprintf(os.Stderr, "API group %s already exists.\n", groupName)
-		os.Exit(-1)
+		log.Fatalf("API group %s already exists.", groupName)
 	}
 }
 

--- a/cmd/apiserver-boot/boot/create_resource_version.go
+++ b/cmd/apiserver-boot/boot/create_resource_version.go
@@ -17,7 +17,7 @@ limitations under the License.
 package boot
 
 import (
-	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 
@@ -41,16 +41,13 @@ func AddCreateVersion(cmd *cobra.Command) {
 
 func RunCreateVersion(cmd *cobra.Command, args []string) {
 	if len(domain) == 0 {
-		fmt.Fprintf(os.Stderr, "apiserver-boot create-version requires the --domain flag\n")
-		os.Exit(-1)
+		log.Fatalf("apiserver-boot create-version requires the --domain flag")
 	}
 	if len(groupName) == 0 {
-		fmt.Fprintf(os.Stderr, "apiserver-boot create-version requires the --group flag\n")
-		os.Exit(-1)
+		log.Fatalf("apiserver-boot create-version requires the --group flag")
 	}
 	if len(versionName) == 0 {
-		fmt.Fprintf(os.Stderr, "apiserver-boot create-version requires the --version flag\n")
-		os.Exit(-1)
+		log.Fatalf("apiserver-boot create-version requires the --version flag")
 	}
 
 	cr := getCopyright()
@@ -65,7 +62,7 @@ func RunCreateVersion(cmd *cobra.Command, args []string) {
 func createVersion(boilerplate string) {
 	dir, err := os.Getwd()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
+		log.Fatalf("%v\n", err)
 		os.Exit(-1)
 	}
 	path := filepath.Join(dir, "pkg", "apis", groupName, versionName, "doc.go")
@@ -77,8 +74,7 @@ func createVersion(boilerplate string) {
 		Repo,
 	})
 	if !created && !ignoreExists {
-		fmt.Fprintf(os.Stderr, "API group version %s/%s already exists.\n", groupName, versionName)
-		os.Exit(-1)
+		log.Fatalf("API group version %s/%s already exists.", groupName, versionName)
 	}
 }
 

--- a/cmd/apiserver-boot/boot/docs.go
+++ b/cmd/apiserver-boot/boot/docs.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 
 	"bytes"
+
 	"github.com/spf13/cobra"
 )
 
@@ -60,8 +61,7 @@ func RunCleanDocs(cmd *cobra.Command, args []string) {
 
 func RunDocs(cmd *cobra.Command, args []string) {
 	if len(server) == 0 {
-		fmt.Fprintf(os.Stderr, "apiserver-boot run requires the --server flag\n")
-		os.Exit(-1)
+		log.Fatal("apiserver-boot run requires the --server flag")
 	}
 
 	c := exec.Command(server,

--- a/cmd/apiserver-boot/boot/generate.go
+++ b/cmd/apiserver-boot/boot/generate.go
@@ -19,6 +19,7 @@ package boot
 import (
 	"fmt"
 	"io/ioutil"
+	"log"
 	"os"
 	"os/exec"
 	"path"
@@ -76,8 +77,7 @@ func RunGenerate(cmd *cobra.Command, args []string) {
 
 	root, err := os.Executable()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
-		os.Exit(-1)
+		log.Fatalf("error: %v", err)
 	}
 	root = filepath.Dir(root)
 
@@ -102,8 +102,7 @@ func RunGenerate(cmd *cobra.Command, args []string) {
 	fmt.Printf("%s\n", strings.Join(c.Args, " "))
 	out, err := c.CombinedOutput()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to run apiregister-gen %s %v\n", out, err)
-		os.Exit(-1)
+		log.Fatalf("failed to run apiregister-gen %s %v", out, err)
 	}
 
 	c = exec.Command(filepath.Join(root, "conversion-gen"),
@@ -116,8 +115,7 @@ func RunGenerate(cmd *cobra.Command, args []string) {
 	fmt.Printf("%s\n", strings.Join(c.Args, " "))
 	out, err = c.CombinedOutput()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to run conversion-gen %s %v\n", out, err)
-		os.Exit(-1)
+		log.Fatalf("failed to run conversion-gen %s %v", out, err)
 	}
 
 	c = exec.Command(filepath.Join(root, "deepcopy-gen"),
@@ -129,8 +127,7 @@ func RunGenerate(cmd *cobra.Command, args []string) {
 	fmt.Printf("%s\n", strings.Join(c.Args, " "))
 	out, err = c.CombinedOutput()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to run deepcopy-gen %s %v\n", out, err)
-		os.Exit(-1)
+		log.Fatalf("failed to run deepcopy-gen %s %v", out, err)
 	}
 
 	c = exec.Command(filepath.Join(root, "openapi-gen"),
@@ -143,8 +140,7 @@ func RunGenerate(cmd *cobra.Command, args []string) {
 	fmt.Printf("%s\n", strings.Join(c.Args, " "))
 	out, err = c.CombinedOutput()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to run openapi-gen %s %v\n", out, err)
-		os.Exit(-1)
+		log.Fatalf("failed to run openapi-gen %s %v", out, err)
 	}
 
 	c = exec.Command(filepath.Join(root, "defaulter-gen"),
@@ -157,8 +153,7 @@ func RunGenerate(cmd *cobra.Command, args []string) {
 	fmt.Printf("%s\n", strings.Join(c.Args, " "))
 	out, err = c.CombinedOutput()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to run defaulter-gen %s %v\n", out, err)
-		os.Exit(-1)
+		log.Fatalf("failed to run defaulter-gen %s %v", out, err)
 	}
 
 	// Builder the versioned apis client
@@ -175,8 +170,7 @@ func RunGenerate(cmd *cobra.Command, args []string) {
 	fmt.Printf("%s\n", strings.Join(c.Args, " "))
 	out, err = c.CombinedOutput()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to run client-gen %s %v\n", out, err)
-		os.Exit(-1)
+		log.Fatalf("failed to run client-gen %s %v", out, err)
 	}
 
 	c = exec.Command(filepath.Join(root, "client-gen"),
@@ -189,8 +183,7 @@ func RunGenerate(cmd *cobra.Command, args []string) {
 	fmt.Printf("%s\n", strings.Join(c.Args, " "))
 	out, err = c.CombinedOutput()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to run client-gen for unversioned APIs %s %v\n", out, err)
-		os.Exit(-1)
+		log.Fatalf("failed to run client-gen for unversioned APIs %s %v", out, err)
 	}
 
 	listerPkg := filepath.Join(clientPkg, "listers_generated")
@@ -203,8 +196,7 @@ func RunGenerate(cmd *cobra.Command, args []string) {
 	fmt.Printf("%s\n", strings.Join(c.Args, " "))
 	out, err = c.CombinedOutput()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to run lister-gen %s %v\n", out, err)
-		os.Exit(-1)
+		log.Fatalf("failed to run lister-gen %s %v", out, err)
 	}
 
 	informerPkg := filepath.Join(clientPkg, "informers_generated")
@@ -220,8 +212,7 @@ func RunGenerate(cmd *cobra.Command, args []string) {
 	fmt.Printf("%s\n", strings.Join(c.Args, " "))
 	out, err = c.CombinedOutput()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to run informer-gen %s %v\n", out, err)
-		os.Exit(-1)
+		log.Fatalf("failed to run informer-gen %s %v", out, err)
 	}
 }
 
@@ -229,15 +220,13 @@ func initApis() {
 	if len(versionedAPIs) == 0 {
 		groups, err := ioutil.ReadDir(filepath.Join("pkg", "apis"))
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "could not read pkg/apis directory to find api versions\n")
-			os.Exit(-1)
+			log.Fatalf("could not read pkg/apis directory to find api versions")
 		}
 		for _, g := range groups {
 			if g.IsDir() {
 				versionFiles, err := ioutil.ReadDir(filepath.Join("pkg", "apis", g.Name()))
 				if err != nil {
-					fmt.Fprintf(os.Stderr, "could not read pkg/apis/%s directory to find api versions\n", g.Name())
-					os.Exit(-1)
+					log.Fatalf("could not read pkg/apis/%s directory to find api versions", g.Name())
 				}
 				for _, v := range versionFiles {
 					if v.IsDir() {

--- a/cmd/apiserver-boot/boot/glide.go
+++ b/cmd/apiserver-boot/boot/glide.go
@@ -17,7 +17,7 @@ limitations under the License.
 package boot
 
 import (
-	"fmt"
+	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -43,13 +43,11 @@ func AddGlideInstallCmd(cmd *cobra.Command) {
 func fetchGlide() {
 	o, err := exec.Command("glide", "-v").CombinedOutput()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "must install glide v0.12 or later\n")
-		os.Exit(-1)
+		log.Fatal("must install glide v0.12 or later")
 	}
 	if !strings.HasPrefix(string(o), "glide version v0.12") &&
 		!strings.HasPrefix(string(o), "glide version v0.13") {
-		fmt.Fprintf(os.Stderr, "must install glide  or later, was %s\n", o)
-		os.Exit(-1)
+		log.Fatalf("must install glide  or later, was %s", o)
 	}
 
 	c := exec.Command("glide", "install", "--strip-vendor")
@@ -57,8 +55,7 @@ func fetchGlide() {
 	c.Stdout = os.Stdout
 	err = c.Run()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to run glide install\n%v\n", err)
-		os.Exit(-1)
+		log.Fatalf("failed to run glide install\n%v\n", err)
 	}
 }
 
@@ -69,7 +66,7 @@ func copyGlide() {
 	// who used `go install` to put `apiserver-boot` in their $GOPATH/bin.
 	e, err := os.Executable()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "unable to get directory of apiserver-builder tools")
+		log.Fatal("unable to get directory of apiserver-builder tools")
 	}
 
 	e = filepath.Dir(filepath.Dir(e))
@@ -80,8 +77,7 @@ func copyGlide() {
 		c.Stdout = os.Stdout
 		err = c.Run()
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "failed to copy go dependencies\n%v\n", err)
-			os.Exit(-1)
+			log.Fatalf("failed to copy go dependencies %v", err)
 		}
 	}
 
@@ -139,8 +135,7 @@ ignore:
 func createGlide() {
 	dir, err := os.Getwd()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
-		os.Exit(-1)
+		log.Fatal(err)
 	}
 	path := filepath.Join(dir, "glide.yaml")
 	writeIfNotFound(path, "glide-template", glideTemplate, glideTemplateArguments{Repo})

--- a/cmd/apiserver-boot/boot/init.go
+++ b/cmd/apiserver-boot/boot/init.go
@@ -17,7 +17,7 @@ limitations under the License.
 package boot
 
 import (
-	"fmt"
+	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -40,8 +40,7 @@ func AddInit(cmd *cobra.Command) {
 
 func RunInit(cmd *cobra.Command, args []string) {
 	if len(domain) == 0 {
-		fmt.Fprintf(os.Stderr, "apiserver-boot init requires the --domain flag\n")
-		os.Exit(-1)
+		log.Fatal("apiserver-boot init requires the --domain flag")
 	}
 	cr := getCopyright()
 
@@ -84,7 +83,7 @@ func main() {
 	flag.Parse()
 	config, err := controllerlib.GetConfig(*kubeconfig)
 	if err != nil {
-		log.Fatalf("Could not create Config for talking to the apiserver: %v\n", err)
+		log.Fatalf("Could not create Config for talking to the apiserver: %v", err)
 	}
 
 	controllers, _ := controller.GetAllControllers(config)
@@ -98,8 +97,7 @@ func main() {
 func createControllerManager(boilerplate string) {
 	dir, err := os.Getwd()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
-		os.Exit(-1)
+		log.Fatal(err)
 	}
 	path := filepath.Join(dir, "cmd", "controller", "main.go")
 	writeIfNotFound(path, "main-template", controllerManagerTemplate, controllerManagerTemplateArguments{boilerplate, Repo})
@@ -136,8 +134,7 @@ func main() {
 func createApiserver(boilerplate string) {
 	dir, err := os.Getwd()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
-		os.Exit(-1)
+		log.Fatal(err)
 	}
 	path := filepath.Join(dir, "cmd", "apiserver", "main.go")
 	writeIfNotFound(path, "apiserver-template", apiserverTemplate, apiserverTemplateArguments{boilerplate, Repo})
@@ -148,8 +145,7 @@ func createPackage(boilerplate, path string) {
 	pkg := filepath.Base(path)
 	dir, err := os.Getwd()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
-		os.Exit(-1)
+		log.Fatal(err)
 	}
 	path = filepath.Join(dir, path, "doc.go")
 	writeIfNotFound(path, "pkg-template", packageDocTemplate, packageDocTemplateArguments{boilerplate, pkg})
@@ -171,8 +167,7 @@ package {{.Package}}
 func createAPIs(boilerplate string) {
 	dir, err := os.Getwd()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
-		os.Exit(-1)
+		log.Fatal(err)
 	}
 	path := filepath.Join(dir, "pkg", "apis", "doc.go")
 	writeIfNotFound(path, "apis-template", apisDocTemplate, apisDocTemplateArguments{boilerplate, domain})

--- a/cmd/apiserver-boot/boot/run.go
+++ b/cmd/apiserver-boot/boot/run.go
@@ -18,13 +18,15 @@ package boot
 
 import (
 	"fmt"
+	"log"
 	"os"
 
-	"github.com/spf13/cobra"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/spf13/cobra"
 )
 
 var runCmd = &cobra.Command{
@@ -90,7 +92,7 @@ func RunEtcd() *exec.Cmd {
 	go func() {
 		err := etcdCmd.Run()
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "Failed to run etcd %v\n", err)
+			log.Fatalf("Failed to run etcd %v", err)
 			os.Exit(-1)
 		}
 	}()
@@ -116,7 +118,7 @@ func RunApiserver() *exec.Cmd {
 
 	err := apiserverCmd.Run()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to run apiserver %v\n", err)
+		log.Fatalf("Failed to run apiserver %v", err)
 		os.Exit(-1)
 	}
 
@@ -138,7 +140,7 @@ func RunControllerManager() *exec.Cmd {
 
 	err := controllerManagerCmd.Run()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to run controller-manager %v\n", err)
+		log.Fatalf("Failed to run controller-manager %v", err)
 		os.Exit(-1)
 	}
 
@@ -149,7 +151,7 @@ func WriteKubeConfig() {
 	// Write a kubeconfig
 	dir, err := os.Getwd()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Cannot get working directory %v\n", err)
+		log.Fatalf("Cannot get working directory %v", err)
 		os.Exit(-1)
 	}
 	path := filepath.Join(dir, "apiserver.local.config", "certificates", "apiserver")

--- a/cmd/apiserver-boot/boot/util.go
+++ b/cmd/apiserver-boot/boot/util.go
@@ -19,6 +19,7 @@ package boot
 import (
 	"fmt"
 	"io/ioutil"
+	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -47,8 +48,7 @@ func writeIfNotFound(path, templateName, templateValue string, data interface{})
 	if _, err := os.Stat(path); err == nil {
 		return false
 	} else if !os.IsNotExist(err) {
-		fmt.Fprintf(os.Stderr, "Could not stat %s: %v\n", path, err)
-		os.Exit(-1)
+		log.Fatalf("Could not stat %s: %v", path, err)
 
 	}
 	create(path)
@@ -62,15 +62,13 @@ func writeIfNotFound(path, templateName, templateValue string, data interface{})
 
 	f, err := os.OpenFile(path, os.O_WRONLY, 0)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to create %s: %v\n", path, err)
-		os.Exit(-1)
+		log.Fatalf("Failed to create %s: %v", path, err)
 	}
 	defer f.Close()
 
 	err = t.Execute(f, data)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Failed to create %s: %v\n", path, err)
-		os.Exit(-1)
+		log.Fatalf("Failed to create %s: %v", path, err)
 	}
 
 	return true
@@ -84,27 +82,23 @@ func getCopyright() string {
 			copyright = "boilerplate.go.txt"
 			cr, err := ioutil.ReadFile(copyright)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "could not read copyright file %s\n", copyright)
-				os.Exit(-1)
+				log.Fatalf("could not read copyright file %s", copyright)
 			}
 			return string(cr)
 		}
 
-		fmt.Fprintf(os.Stderr, "apiserver-boot create-resource requires the --copyright flag if boilerplate.go.txt does not exist\n")
-		os.Exit(-1)
+		log.Fatalf("apiserver-boot create-resource requires the --copyright flag if boilerplate.go.txt does not exist")
 	}
 
 	if _, err := os.Stat(copyright); err != nil {
 		if !os.IsNotExist(err) {
-			fmt.Fprintf(os.Stderr, "Could not stat %s: %v\n", copyright, err)
-			os.Exit(-1)
+			log.Fatalf("Could not stat %s: %v", copyright, err)
 		}
 		return ""
 	} else {
 		cr, err := ioutil.ReadFile(copyright)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "could not read copyright file %s\n", copyright)
-			os.Exit(-1)
+			log.Fatalf("could not read copyright file %s", copyright)
 		}
 		return string(cr)
 	}

--- a/cmd/apiserver-boot/main.go
+++ b/cmd/apiserver-boot/main.go
@@ -17,7 +17,7 @@ limitations under the License.
 package main
 
 import (
-	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -32,24 +32,20 @@ var wd string
 func main() {
 	gopath = os.Getenv("GOPATH")
 	if len(gopath) == 0 {
-		fmt.Fprintf(os.Stderr, "GOPATH not defined\n")
-		os.Exit(-1)
+		log.Fatal("GOPATH not defined")
 	}
 	boot.GoSrc = filepath.Join(gopath, "src")
 
 	var err error
 	wd, err = os.Getwd()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
-		os.Exit(-1)
+		log.Fatal(err)
 	}
 
 	if !strings.HasPrefix(filepath.Dir(wd), boot.GoSrc) {
-		fmt.Fprintf(os.Stderr,
-			"apiserver-boot must be run from the directory containing the go package to "+
-				"bootstrap. This must be under $GOPATH/src/<package>. "+
-				"\nCurrent GOPATH=%s.  \nCurrent directory=%s\n", gopath, wd)
-		os.Exit(-1)
+		log.Fatalf("apiserver-boot must be run from the directory containing the go package to "+
+			"bootstrap. This must be under $GOPATH/src/<package>. "+
+			"\nCurrent GOPATH=%s.  \nCurrent directory=%s", gopath, wd)
 	}
 	boot.Repo = strings.Replace(wd, boot.GoSrc+"/", "", 1)
 	boot.AddCreateGroup(cmd)
@@ -63,8 +59,7 @@ func main() {
 	boot.AddBuild(cmd)
 
 	if err := cmd.Execute(); err != nil {
-		fmt.Fprintf(os.Stderr, "%v", err)
-		os.Exit(-1)
+		log.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
This saves a surprising amount of complexity, two lines at a time.

Instead of

```go
fmt.Fprintf(os.Stderr, "GOPATH not defined\n")
os.Exit(-1)
```

write

```go
log.Fatal("GOPATH not defined")
```

@pwittrock 