### PR TITLE
Ease of use improvements for apiserver-boot

### DIFF
--- a/cmd/apiserver-boot/boot/build.go
+++ b/cmd/apiserver-boot/boot/build.go
@@ -27,6 +27,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var generateForBuild bool
+
 var createBuildCmd = &cobra.Command{
 	Use:   "build",
 	Short: "Creates an API resource",
@@ -36,9 +38,15 @@ var createBuildCmd = &cobra.Command{
 
 func AddBuild(cmd *cobra.Command) {
 	cmd.AddCommand(createBuildCmd)
+
+	createBuildCmd.Flags().BoolVar(&generateForBuild, "generate", true, "if true, generate code before building")
 }
 
 func RunBuild(cmd *cobra.Command, args []string) {
+	if generateForBuild {
+		RunGenerate(cmd, args)
+	}
+
 	path := filepath.Join("cmd", "apiserver", "main.go")
 	c := exec.Command("go", "build", "-o", "bin/apiserver", path)
 	fmt.Printf("%s\n", strings.Join(c.Args, " "))

--- a/cmd/apiserver-boot/boot/build.go
+++ b/cmd/apiserver-boot/boot/build.go
@@ -44,6 +44,7 @@ func AddBuild(cmd *cobra.Command) {
 
 func RunBuild(cmd *cobra.Command, args []string) {
 	if generateForBuild {
+		log.Printf("regenerating generated code.  To disable regeneration, run with --generate=false.")
 		RunGenerate(cmd, args)
 	}
 

--- a/cmd/apiserver-boot/boot/create_resource.go
+++ b/cmd/apiserver-boot/boot/create_resource.go
@@ -21,6 +21,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/markbates/inflect"
@@ -45,6 +46,10 @@ func AddCreateResource(cmd *cobra.Command) {
 }
 
 func RunCreateResource(cmd *cobra.Command, args []string) {
+	if _, err := os.Stat("pkg"); err != nil {
+		log.Fatalf("could not find 'pkg' directory.  must run apiserver-boot init before creating resources")
+	}
+
 	if len(domain) == 0 {
 		log.Fatal("apiserver-boot create-resource requires the --domain flag")
 	}
@@ -59,6 +64,19 @@ func RunCreateResource(cmd *cobra.Command, args []string) {
 	}
 	if len(resourceName) == 0 {
 		resourceName = inflect.NewDefaultRuleset().Pluralize(strings.ToLower(kindName))
+	}
+
+	if strings.ToLower(groupName) != groupName {
+		log.Fatalf("--group must be lowercase was (%s)", groupName)
+	}
+	versionMatch := regexp.MustCompile("^v\\d+(alpha\\d+|beta\\d+)$")
+	if !versionMatch.MatchString(versionName) {
+		log.Fatalf(
+			"--version has bad format. must match ^v\\d+(alpha\\d+|beta\\d+)$.  "+
+				"e.g. v1alpha1,v1beta1,v1 was(%s)", versionName)
+	}
+	if string(kindName[0]) != strings.ToUpper(string(kindName[0])) {
+		log.Fatalf("--kind must start with uppercase letter was (%s)", kindName)
 	}
 
 	cr := getCopyright()

--- a/cmd/apiserver-boot/boot/create_resource_group.go
+++ b/cmd/apiserver-boot/boot/create_resource_group.go
@@ -22,6 +22,7 @@ import (
 	"path/filepath"
 
 	"github.com/spf13/cobra"
+	"strings"
 )
 
 var createGroupCmd = &cobra.Command{
@@ -39,12 +40,21 @@ func AddCreateGroup(cmd *cobra.Command) {
 }
 
 func RunCreateGroup(cmd *cobra.Command, args []string) {
+	if _, err := os.Stat("pkg"); err != nil {
+		log.Fatalf("could not find 'pkg' directory.  must run apiserver-boot init before creating resources")
+	}
+
 	if len(domain) == 0 {
 		log.Fatalf("apiserver-boot create-group requires the --domain flag")
 	}
 	if len(groupName) == 0 {
 		log.Fatalf("apiserver-boot create-group requires the --groupName flag")
 	}
+
+	if strings.ToLower(groupName) != groupName {
+		log.Fatalf("--group must be lowercase was (%s)", groupName)
+	}
+
 	cr := getCopyright()
 	createGroup(cr)
 }

--- a/cmd/apiserver-boot/boot/create_resource_version.go
+++ b/cmd/apiserver-boot/boot/create_resource_version.go
@@ -20,6 +20,8 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -40,6 +42,10 @@ func AddCreateVersion(cmd *cobra.Command) {
 }
 
 func RunCreateVersion(cmd *cobra.Command, args []string) {
+	if _, err := os.Stat("pkg"); err != nil {
+		log.Fatalf("could not find 'pkg' directory.  must run apiserver-boot init before creating resources")
+	}
+
 	if len(domain) == 0 {
 		log.Fatalf("apiserver-boot create-version requires the --domain flag")
 	}
@@ -48,6 +54,16 @@ func RunCreateVersion(cmd *cobra.Command, args []string) {
 	}
 	if len(versionName) == 0 {
 		log.Fatalf("apiserver-boot create-version requires the --version flag")
+	}
+
+	if strings.ToLower(groupName) != groupName {
+		log.Fatalf("--group must be lowercase was (%s)", groupName)
+	}
+	versionMatch := regexp.MustCompile("^v\\d+(alpha\\d+|beta\\d+)$")
+	if !versionMatch.MatchString(versionName) {
+		log.Fatalf(
+			"--version has bad format. must match ^v\\d+(alpha\\d+|beta\\d+)$.  "+
+				"e.g. v1alpha1,v1beta1,v1 was(%s)", versionName)
 	}
 
 	cr := getCopyright()

--- a/cmd/apiserver-boot/boot/init.go
+++ b/cmd/apiserver-boot/boot/init.go
@@ -60,6 +60,7 @@ func RunInit(cmd *cobra.Command, args []string) {
 	exec.Command("mkdir", "-p", filepath.Join("bin")).CombinedOutput()
 
 	if installDeps {
+		log.Printf("installing godeps.  To disable this, run with --install-deps=false.")
 		copyGlide()
 	}
 }

--- a/cmd/apiserver-boot/boot/init.go
+++ b/cmd/apiserver-boot/boot/init.go
@@ -32,10 +32,13 @@ var initCmd = &cobra.Command{
 	Run:   RunInit,
 }
 
+var installDeps bool
+
 func AddInit(cmd *cobra.Command) {
 	cmd.AddCommand(initCmd)
 	initCmd.Flags().StringVar(&domain, "domain", "", "domain the api groups live under")
 	initCmd.Flags().StringVar(&copyright, "copyright", "", "path to copyright file.  defaults to boilerplate.go.txt")
+	initCmd.Flags().BoolVar(&installDeps, "install-deps", true, "if true, install the vendored deps")
 }
 
 func RunInit(cmd *cobra.Command, args []string) {
@@ -56,6 +59,9 @@ func RunInit(cmd *cobra.Command, args []string) {
 
 	exec.Command("mkdir", "-p", filepath.Join("bin")).CombinedOutput()
 
+	if installDeps {
+		copyGlide()
+	}
 }
 
 type controllerManagerTemplateArguments struct {


### PR DESCRIPTION
- Automatically run `glide-install` with `init`
- Automatically run `generate` with `build`
- Validate that the group, version, kind are formatted correctly