### PR TITLE
Fix informer interface usage for CamelCased resource kinds

### DIFF
--- a/cmd/apiregister-gen/generators/controller_generator.go
+++ b/cmd/apiregister-gen/generators/controller_generator.go
@@ -22,6 +22,7 @@ import (
 	"text/template"
 
 	"k8s.io/gengo/generator"
+	"github.com/markbates/inflect"
 )
 
 type controllerGenerator struct {
@@ -225,6 +226,7 @@ func (d *informersGenerator) Finalize(context *generator.Context, w io.Writer) e
 	temp := template.Must(template.New("informersGenerator-template").Funcs(
 		template.FuncMap{
 			"title": strings.Title,
+			"plural": inflect.NewDefaultRuleset().Pluralize,
 		},
 	).Parse(InformersTemplate))
 	return temp.Execute(w, d.Controllers)
@@ -248,7 +250,7 @@ func NewSharedInformers(config *rest.Config, shutdown <-chan struct{}) *SharedIn
 // startInformers starts all of the informers
 func (si *SharedInformers) startInformers(shutdown <-chan struct{}) {
 	{{ range $c := . -}}
-	go si.Factory.{{title $c.Target.Group}}().{{title $c.Target.Version}}().{{title $c.Resource}}().Informer().Run(shutdown)
+	go si.Factory.{{title $c.Target.Group}}().{{title $c.Target.Version}}().{{plural $c.Target.Kind}}().Informer().Run(shutdown)
 	{{ end -}}
 }
 

--- a/cmd/apiserver-boot/boot/create_resource.go
+++ b/cmd/apiserver-boot/boot/create_resource.go
@@ -292,7 +292,7 @@ var _ = Describe("{{.Kind}}", func() {
 	Describe("when sending a storage request", func() {
 		Context("for a valid config", func() {
 			It("should provide CRUD access to the object", func() {
-				client = cs.{{ title .Group}}{{title .Version}}Client.{{title .Resource}}("{{lower .Kind}}-test-valid")
+				client = cs.{{ title .Group}}{{title .Version}}Client.{{plural .Kind}}("{{lower .Kind}}-test-valid")
 
 				By("returning success from the create request")
 				actual, err := client.Create(&instance)
@@ -362,7 +362,7 @@ func (c *{{.Kind}}ControllerImpl) Init(
 	queue workqueue.RateLimitingInterface) {
 
 	// Set the informer and lister for subscribing to events and indexing {{.Resource}} labels
-	i := si.Factory.{{title .Group}}().{{title .Version}}().{{title .Resource}}()
+	i := si.Factory.{{title .Group}}().{{title .Version}}().{{plural .Kind}}()
 	c.informer = i.Informer()
 	c.lister = i.Lister()
 
@@ -466,7 +466,7 @@ var _ = Describe("{{ .Kind }} controller", func() {
 
 	Describe("when creating a new object", func() {
 		It("invoke the reconcile method", func() {
-			client = cs.{{title .Group}}{{title .Version}}Client.{{ title .Resource }}("{{lower .Kind }}-controller-test-handler")
+			client = cs.{{title .Group}}{{title .Version}}Client.{{ plural .Kind }}("{{lower .Kind }}-controller-test-handler")
 			before = make(chan struct{})
 			after = make(chan struct{})
 

--- a/cmd/apiserver-boot/boot/util.go
+++ b/cmd/apiserver-boot/boot/util.go
@@ -25,6 +25,7 @@ import (
 	"path/filepath"
 	"strings"
 	"text/template"
+	"github.com/markbates/inflect"
 )
 
 var server string
@@ -57,6 +58,7 @@ func writeIfNotFound(path, templateName, templateValue string, data interface{})
 		template.FuncMap{
 			"title": strings.Title,
 			"lower": strings.ToLower,
+			"plural": inflect.NewDefaultRuleset().Pluralize,
 		},
 	).Parse(templateValue))
 


### PR DESCRIPTION
informer-gen generates field names for the versioned interface by
making plural forms of the names of the corresponding resource kinds.
apiregister-gen, in its turn, generates code that references these fields by
uppercased resource name form. That is, when creating a CamelCasedType resource
kind, apiregister-gen inserts calls to Camelcasedtypes(), while informer-gen
generates CamelCasedTypes() interface field name.

Fix apiregister-gen to use the same form of these names as informer-gen.