### PR TITLE
[docs] Point README at concepts index

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,10 @@ Instructions for how to implement custom APIs on top of the apiserver-builder li
 
 #### Concept guides
 
-Conceptual information on addon apiservers.
+Conceptual information on addon apiservers, such as how auth works and how they interact
+with the main Kubernetes API server and API aggregator.
 
-[auth](docs/concepts/auth.md)
+[Concepts](docs/concepts/README.md)
 
 ## Additional material
 


### PR DESCRIPTION
The README current points at one of the individual concepts docs (the
auth one).  It should point at the concepts readme, which has a list of
all the concepts docs (that way, we don't have to maintain a list in two
seperate places).