### PR TITLE
Better support for non-apiserver-builder repos

### DIFF
--- a/cmd/apiserver-boot/boot/build/docs.go
+++ b/cmd/apiserver-boot/boot/build/docs.go
@@ -81,10 +81,12 @@ apiserver-boot build docs --generate-toc=false
 var operations, buildOpenapi, generateToc bool
 var server string
 var disableDelegatedAuth bool
+var cleanup bool
 var outputDir string
 
 func AddDocs(cmd *cobra.Command) {
 	docsCmd.Flags().StringVar(&server, "server", "bin/apiserver", "path to apiserver binary to run to get swagger.json")
+	docsCmd.Flags().BoolVar(&cleanup, "cleanup", true, "If true, cleanup intermediary files")
 	docsCmd.Flags().BoolVar(&buildOpenapi, "build-openapi", true, "If true, run the server and get the new swagger.json")
 	docsCmd.Flags().BoolVar(&operations, "operations", false, "if true, include operations in docs.")
 	docsCmd.Flags().BoolVar(&generateToc, "generate-toc", true, "If true, generate the table of contents from the api groups instead of using a statically configured ToC.")
@@ -188,5 +190,16 @@ func RunDocs(cmd *cobra.Command, args []string) {
 	err = c.Run()
 	if err != nil {
 		log.Fatalf("error: %v\n", err)
+	}
+
+	// Cleanup intermediate files
+	if cleanup {
+		os.RemoveAll(filepath.Join(wd, outputDir, "includes"))
+		os.RemoveAll(filepath.Join(wd, outputDir, "manifest.json"))
+		os.RemoveAll(filepath.Join(wd, outputDir, "openapi-spec"))
+		os.RemoveAll(filepath.Join(wd, outputDir, "build", "documents"))
+		os.RemoveAll(filepath.Join(wd, outputDir, "build", "documents"))
+		os.RemoveAll(filepath.Join(wd, outputDir, "build", "runbrodocs.sh"))
+		os.RemoveAll(filepath.Join(wd, outputDir, "build", "node_modules", "marked", "Makefile"))
 	}
 }

--- a/cmd/apiserver-boot/boot/create/create.go
+++ b/cmd/apiserver-boot/boot/create/create.go
@@ -37,10 +37,11 @@ apiserver-boot create group --group insect --version v1beta`,
 	Run: RunCreate,
 }
 
-var copyright string = "boilerplate.go.txt"
+var copyright string
 
 func AddCreate(cmd *cobra.Command) {
 	cmd.AddCommand(createCmd)
+	cmd.Flags().StringVar(&copyright, "copyright", "boilerplate.go.txt", "Location of copyright boilerplate file.")
 	AddCreateGroup(createCmd)
 }
 

--- a/cmd/apiserver-boot/boot/init_repo/repo.go
+++ b/cmd/apiserver-boot/boot/init_repo/repo.go
@@ -36,13 +36,14 @@ var repoCmd = &cobra.Command{
 
 var installDeps bool
 var domain string
-var copyright string = "boilerplate.go.txt"
+var copyright string
 
 func AddInitRepo(cmd *cobra.Command) {
 	cmd.AddCommand(repoCmd)
 	repoCmd.Flags().StringVar(&domain, "domain", "", "domain the api groups live under")
 
 	// Hide this flag by default
+	repoCmd.Flags().StringVar(&copyright, "copyright", "boilerplate.go.txt", "Location of copyright boilerplate file.")
 	repoCmd.Flags().
 		BoolVar(&installDeps, "install-deps", true, "if true, install the vendored deps packaged with apiserver-boot.")
 	repoCmd.Flags().MarkHidden("install-deps")


### PR DESCRIPTION
- Clean up intermediate files after generating docs
- Support both k8s.io/client-go and k8s.io/api types when generating openapi
- Allow copyright file to be specified in a flag