### PR TITLE
travis: add a new test case to create a test api server from scratch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,23 @@
 language: go
 
 go:
-- 1.8.1
+- 1.8.3
+
+go_import_path: github.com/kubernetes-incubator/apiserver-builder
+
+cache:
+  directories:
+  - $HOME/.glide
 
 git:
   depth: 3
 
+env:
+  - TEST=example
+  - TEST=test
+
 install:
-- scripts/install_etcd.sh
+  - scripts/install_etcd.sh
 
 script:
-- cd example
-- PATH=$PATH:/tmp/test-etcd make test
+        ./test/travis.sh

--- a/cmd/apiserver-boot/boot/create/resource.go
+++ b/cmd/apiserver-boot/boot/create/resource.go
@@ -425,7 +425,7 @@ func (c *{{.Kind}}ControllerImpl) Reconcile(u *{{.Version}}.{{.Kind}}) error {
 }
 
 func (c *{{.Kind}}ControllerImpl) Get(namespace, name string) (*{{.Version}}.{{.Kind}}, error) {
-	return c.lister.{{ if not .NonNamespacedKind }}{{ title .Resource }}(namespace).{{ end }}Get(name)
+	return c.lister.{{ if not .NonNamespacedKind }}{{plural .Kind}}(namespace).{{ end }}Get(name)
 }
 `
 

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,0 +1,49 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+.PHONY: all test build generate docs cmds clean cleangenerated cleandocs skeleton
+
+all: test
+
+test: build
+	go test ./pkg/...
+	bash -c "find pkg/apis/ -name apiserver.local.config | xargs rm -rf"
+
+skeleton: cmds
+	apiserver-boot init repo --domain sample.kubernetes.io
+	apiserver-boot create group version resource --group storage --version v1 --kind VolumeClaim
+	apiserver-boot create group version resource --group storage --version v1 --kind SnapshotClaim
+	apiserver-boot create group version resource --group storage --version v1 --kind Volume --non-namespaced
+	apiserver-boot create group version resource --group storage --version v1 --kind Snapshot --non-namespaced
+
+build: cmds skeleton
+	apiserver-boot build executables
+
+# Build docs
+docs: cleandocs build
+	apiserver-boot build docs --server bin/apiserver
+
+# Build the tools
+# Note: These are available in the apiserver-builder release tar.gz
+cmds:
+	./build-tools.sh
+
+# Clean up functions
+clean: cleangenerated cleandocs
+
+cleangenerated: cmds
+	apiserver-boot build generated clean
+
+cleandocs: cmds
+	apiserver-boot build docs clean

--- a/test/boilerplate.go.txt
+++ b/test/boilerplate.go.txt
@@ -1,0 +1,16 @@
+/*
+Copyright YEAR The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+

--- a/test/build-tools.sh
+++ b/test/build-tools.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -x -e
+
+# NOTE: Do not copy this file unless you need to use apiserver-builder at HEAD.
+# Otherwise, download the pre-built apiserver-builder tar release from
+# https://github.com/kubernetes-incubator/apiserver-builder/releases instead.
+
+(
+	cd /home/travis/gopath/src/github.com/
+	mkdir Masterminds
+	cd Masterminds
+	git clone https://github.com/Masterminds/glide.git
+	cd glide
+	make build
+)
+
+export PATH=/home/travis/gopath/src/github.com/Masterminds/glide:$PATH
+
+# Install generators from this repo
+cd ..
+go build -o bin/apiserver-builder-release cmd/apiserver-builder-release/main.go
+./bin/apiserver-builder-release vendor --version 1.0
+./bin/apiserver-builder-release build --version 1.0 --targets linux:amd64
+
+tar -xzf apiserver-builder-1.0-linux-amd64.tar.gz -C test

--- a/test/travis.sh
+++ b/test/travis.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -x -e
+
+if [ "$TEST" == "example" ]; then
+	cd example
+	PATH=$PATH:/tmp/test-etcd make test
+elif [ "$TEST" == "test" ]; then
+	cd test
+	PATH=$PATH:/tmp/test-etcd:`pwd`/bin/ make test
+fi


### PR DESCRIPTION
    This test does these action:
    * build an apserver-boot tarball
    * genereate a test api server with namespaces and non-namespaced
      resources.
    * run tests for this api server
