### PR TITLE
Additional fields for apiserver.yaml

### DIFF
--- a/cmd/apiserver-boot/boot/build/build_resource_config.go
+++ b/cmd/apiserver-boot/boot/build/build_resource_config.go
@@ -320,15 +320,14 @@ spec:
         api: {{.Name}}
         apiserver: "true"
     spec:
-      {{if .ImagePullSecrets}}
+      {{- if .ImagePullSecrets }}
       imagePullSecrets:
-        {{range .ImagePullSecrets}}
-      - name: {{.}}      
-        {{end}}
-      {{end}}
-      {{if .ServiceAccount}}
-      serviceAccount: .ServiceAccount
-      {{end}}
+      {{range .ImagePullSecrets }}- name: {{.}}
+      {{ end }}
+      {{- end -}}
+      {{- if .ServiceAccount }}
+      serviceAccount: {{.ServiceAccount}}
+      {{- end }}
       containers:
       - name: apiserver
         image: {{.Image}}

--- a/docs/running_in_cluster.md
+++ b/docs/running_in_cluster.md
@@ -46,6 +46,10 @@ This will perform the following:
 present and runnable from "./".  You may need to manually edit the config if your
 container looks differently.
 
+You can also provide optional flags:
+- `image-pull-secrets` secrets that will be used by k8s cluster if your image is stored in private registry
+- `service-account` service account name that will be used by deployment, can be used to provide additional rights for running container
+
 ### Run the apiserver
 
 `kubectl apply -f config/apiserver.yaml`


### PR DESCRIPTION
Currently I'm unable to generate and deploy api server with just one command, because I'm using secured private docker registry and k8s cluster with RBAC enabled.

What solves problem for me is editing apiserver.yaml and adding ImagePullSecrets and ServiceAccount to apiserver deployment. But doing this manually is cumbersome.

I would like to run it on one command like this (and this pull request enables it):
```
apiserver-boot run in-cluster --name group_name --namespace default --image private_repo/IMAGE --image-pull-secrets private_repo_secret --service-account service_account_with_rights
```

Currently I need to run:
```
    apiserver-boot build container --image $IMAGE_NAME
    docker push $IMAGE_NAME
    rm config/apiserver.yaml
    apiserver-boot build config --name remoteenvsgroup --namespace default --image $IMAGE_NAME
```
and then edit `apiserver.yaml` and run `kubectl apply`.


Also I have seen `controller-secret` flag but it is not used and I'm not sure if it place holder for `image-pull-secrets` functionality.

