### PR TITLE
Fix typos in api_building_overview.md

### DIFF
--- a/docs/concepts/api_building_overview.md
+++ b/docs/concepts/api_building_overview.md
@@ -270,13 +270,13 @@ new values against old values.  This is useful for enforcing immutability of
 certain fields.
 
 If unspecified in your type, a default ValidateUpdate will be provided
-by the apiserver-builder.  Can be overriden by specifying the function
+by the apiserver-builder.  Can be overridden by specifying the function
 `<ResourceType>Strategy.ValidateUpdate`.
 
 *PrepareForUpdate*: Similar to PrepareForCreate, but for update operations.
 
 If unspecified in your type, a default PrepareForUpdate will be provided
-by the apiserver-builder.  Can be overriden by specifying the function
+by the apiserver-builder.  Can be overridden by specifying the function
 `<ResourceType>Strategy.PrepareForUpdate`.
 
 


### PR DESCRIPTION
Fix a typo:
Line 273/279: overriden->overridden
